### PR TITLE
Disable line-numbers plugin and add documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,16 @@ After running coverage report, to open graphic interface version:
 ```
 open coverage/lcov-report/index.html
 ```
+
+### Technologies and Frameworks
+
+- React
+- Redux
+- Apollo Client & GraphQL
+- Jest & React Testing Library
+- Prism.js
+
+### Resource Credits
+
+ - Boilerplate code for a Prism component: https://betterstack.dev/blog/code-highlighting-in-react-using-prismjs/
+ - "Tomorrow Night" theme CSS for syntax highlighting: https://prismjs.com/

--- a/src/components/ResultCard/ResultCard.jsx
+++ b/src/components/ResultCard/ResultCard.jsx
@@ -30,7 +30,7 @@ export const ResultCard = ({rating, method, resultId, handleVote}) => {
                <Snippet
                 code={snippet}
                 language="js"
-                plugins={["line-numbers"]}
+                plugins={[]}
               />
             </section>
         </div>

--- a/src/components/Snippet/Snippet.jsx
+++ b/src/components/Snippet/Snippet.jsx
@@ -6,17 +6,21 @@ export class Snippet extends Component {
     super(props)
     this.ref = React.createRef()
   }
+
   componentDidMount() {
     this.highlight()
   }
+
   componentDidUpdate() {
     this.highlight()
   }
+
   highlight = () => {
     if (this.ref && this.ref.current) {
       Prism.highlightElement(this.ref.current)
     }
   }
+
   render() {
     const { code, plugins, language } = this.props
     return (
@@ -28,4 +32,5 @@ export class Snippet extends Component {
     )
   }
 }
+
 export default Snippet

--- a/src/components/SourceMethod/SourceMethod.jsx
+++ b/src/components/SourceMethod/SourceMethod.jsx
@@ -24,7 +24,7 @@ let { id, name, description, syntax, snippet, docsUrl} = props.sourceMethod
                <Snippet
                 code={snippet}
                 language="js"
-                plugins={["line-numbers"]}
+                plugins={[]}
               />
             </section>
         </div>

--- a/src/styles/ResultCard.scss
+++ b/src/styles/ResultCard.scss
@@ -112,9 +112,3 @@ span {
   height: auto;
   margin-left: 2%;
 }
-
-.code-snippet {
-  font-family: courier,
-    monospace;
-  font-size: .9em;
-}

--- a/src/styles/SourceMethod.scss
+++ b/src/styles/SourceMethod.scss
@@ -46,9 +46,3 @@ $snow: #FFFAFB;
   height: 100px;
   // margin-left: 2%;
 }
-
-.code-snippet {
-  font-family: courier,
-  monospace;
-  font-size: .9em;
-}


### PR DESCRIPTION
### Sidebar Checklist
​
- [x] Ran test suite
- [x] Request reviewers
- [x] Assign yourself and other contributors
- [x] Link to project
- [x] Added to Readme
​
### Issues Resolved
Resolves #51 
​
### Problem Addressed
Prism "line-numbers" plugin was not working; it created gutters where line numbers should have been, but they weren't being displayed.
​
### Solution Implemented
Disabled plugin after attempting several different fixes. It's possibly related to the way the snippets are stored as a single string (although they have newline characters within them).​

### Screenshots (optional)
![](https://media.giphy.com/media/11EVpyEaQQvSVi/source.gif)
​
### Other Notes
No new functionality!